### PR TITLE
Set default userAgent as Firefox. Fix bug with tab collapse/expand (https://bugs.openjdk.java.net/browse/JDK-8090517)

### DIFF
--- a/src/io/loli/browserfx/JavaFxBrowserView.java
+++ b/src/io/loli/browserfx/JavaFxBrowserView.java
@@ -18,6 +18,8 @@ import java.util.function.Consumer;
 
 public class JavaFxBrowserView implements BrowserView {
 
+    private static final String userAgent = "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:60.0) Gecko/20100101 Firefox/60.0";
+
     private WebView browser;
     private WebEngine webEngine;
     private String url;
@@ -75,6 +77,7 @@ public class JavaFxBrowserView implements BrowserView {
         Platform.runLater(() -> {
             browser = new WebView();
             webEngine = browser.getEngine();
+            webEngine.setUserAgent(userAgent);
         });
     }
 

--- a/src/io/loli/browserfx/JavaFxBrowserView.java
+++ b/src/io/loli/browserfx/JavaFxBrowserView.java
@@ -74,6 +74,7 @@ public class JavaFxBrowserView implements BrowserView {
     @Override
     public void reload() {
         jfxPanel = new JFXPanel();
+        Platform.setImplicitExit(false);
         Platform.runLater(() -> {
             browser = new WebView();
             webEngine = browser.getEngine();
@@ -83,6 +84,7 @@ public class JavaFxBrowserView implements BrowserView {
 
     @Override
     public void urlChangeCallback(Consumer<String> consumer) {
+        Platform.setImplicitExit(false);
         Platform.runLater(() -> {
             webEngine.getLoadWorker().stateProperty().addListener((ov, oldState, newState) -> {
                 consumer.accept(webEngine.getLocation());
@@ -92,6 +94,7 @@ public class JavaFxBrowserView implements BrowserView {
 
     @Override
     public JComponent getNode() {
+        Platform.setImplicitExit(false);
         Platform.runLater(() -> {
             BorderPane borderPane = new BorderPane();
             borderPane.setCenter(browser);


### PR DESCRIPTION
1. Some web site lock unknown browsers.
2. Google switch styles for unknown userAgents.

Old Style Google:
![selection_004](https://user-images.githubusercontent.com/5312683/40714625-d7c9330e-640b-11e8-8c54-29548be02af1.png)

New Style Google:
![selection_005](https://user-images.githubusercontent.com/5312683/40714642-e59981f0-640b-11e8-9b4a-7f515368fb9b.png)


